### PR TITLE
4238: ad-login intermediary info page

### DIFF
--- a/os2forms_nemlogin_openid_connect.module
+++ b/os2forms_nemlogin_openid_connect.module
@@ -11,6 +11,7 @@ use Drupal\os2forms_nemlogin_openid_connect\Helper\Settings;
 use Drupal\os2forms_nemlogin_openid_connect\Helper\WebformHelper;
 use Drupal\webform\WebformSubmissionInterface;
 
+
 /**
  * Implements hook_help().
  */
@@ -65,6 +66,11 @@ function os2forms_nemlogin_openid_connect_theme(array $existing, string $type, s
         'users' => NULL,
         'plugin' => NULL,
         'query' => NULL,
+      ],
+    ],
+    'os2forms-nemlogin-openid-connect-intermediary-info-page' => [
+      'variables' => [
+        'redirect_url' => NULL,
       ],
     ],
   ];

--- a/os2forms_nemlogin_openid_connect.routing.yml
+++ b/os2forms_nemlogin_openid_connect.routing.yml
@@ -25,3 +25,13 @@ os2forms_nemlogin_openid_connect.admin.settings:
     _title: 'OS2Forms NemLogin OpenID Connect settings'
   requirements:
     _permission: 'administer site configuration'
+
+os2forms_nemlogin_openid_connect.info_page:
+  path: '/info-page'
+  defaults:
+    _controller: 'Drupal\os2forms_nemlogin_openid_connect\Controller\OpenIDConnectController::infoPage'
+  requirements:
+    # Anonymous users must be able to access this route.
+    _access: 'TRUE'
+  options:
+    no_cache: 'TRUE'

--- a/src/Controller/OpenIDConnectController.php
+++ b/src/Controller/OpenIDConnectController.php
@@ -21,6 +21,7 @@ use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -81,6 +82,24 @@ class OpenIDConnectController implements ContainerInjectionInterface {
     private readonly RendererInterface $renderer,
   ) {
     $this->setLogger($logger);
+  }
+
+  public function infoPage(): array {
+    $request = $this->requestStack->getCurrentRequest();
+    $pluginId = $request->query->get('id');
+
+    $redirect_url = Url::fromRoute('os2forms_nemlogin_openid_connect.openid_connect_authenticate', [
+      'id' => $pluginId,
+      OpenIDConnectController::QUERY_LOCATION_NAME => $request->getRequestUri(),
+    ])
+      ->toString(TRUE)
+      ->getGeneratedUrl();
+
+    // Render the template.
+    return [
+      '#theme' => 'os2forms-nemlogin-openid-connect-intermediary-info-page',
+      '#redirect_url' => $redirect_url,
+    ];
   }
 
   /**

--- a/src/Plugin/os2web/NemloginAuthProvider/OpenIDConnect.php
+++ b/src/Plugin/os2web/NemloginAuthProvider/OpenIDConnect.php
@@ -169,13 +169,16 @@ class OpenIDConnect extends AuthProviderBase {
    *   The response.
    */
   public function login() {
-    $info_page_url = Url::fromRoute('os2forms_nemlogin_openid_connect.info_page', [
-      'id' => $this->getPluginId(),
-    ])
-      ->toString(TRUE)
-      ->getGeneratedUrl();
 
-    return (new LocalRedirectResponse($info_page_url))->send();
+    if ("openid_connect_ad" === $this->getPluginId()) {
+      $info_page_url = Url::fromRoute('os2forms_nemlogin_openid_connect.info_page', [
+        'id' => $this->getPluginId(),
+      ])
+        ->toString(TRUE)
+        ->getGeneratedUrl();
+
+      return (new LocalRedirectResponse($info_page_url))->send();
+    }
 
     $token = $this->getToken();
     if (NULL === $token) {

--- a/src/Plugin/os2web/NemloginAuthProvider/OpenIDConnect.php
+++ b/src/Plugin/os2web/NemloginAuthProvider/OpenIDConnect.php
@@ -39,6 +39,10 @@ class OpenIDConnect extends AuthProviderBase {
   private const SESSION_TOKEN = 'os2forms_nemlogin_openid_connect.user_token';
 
   /**
+   * Plugin id for AD login
+   */
+  private const OPENIDCONNECT_AD = 'openid_connect_ad';
+  /**
    * Fetch only mode flag.
    *
    * @var bool
@@ -169,8 +173,10 @@ class OpenIDConnect extends AuthProviderBase {
    *   The response.
    */
   public function login() {
+    $request = $this->requestStack->getCurrentRequest();
 
-    if ("openid_connect_ad" === $this->getPluginId()) {
+    // If form requires AD-login, show info-page regarding AD-roles.
+    if (self::OPENIDCONNECT_AD === $this->getPluginId()) {
       $info_page_url = Url::fromRoute('os2forms_nemlogin_openid_connect.info_page', [
         'id' => $this->getPluginId(),
       ])

--- a/src/Plugin/os2web/NemloginAuthProvider/OpenIDConnect.php
+++ b/src/Plugin/os2web/NemloginAuthProvider/OpenIDConnect.php
@@ -29,6 +29,7 @@ use Symfony\Component\Yaml\Yaml;
  * )
  */
 class OpenIDConnect extends AuthProviderBase {
+
   use LoggerTrait;
   use LoggerAwareTrait;
 
@@ -96,7 +97,8 @@ class OpenIDConnect extends AuthProviderBase {
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     // Shamelessly lifted from Drupal\os2web_nemlogin\Plugin\AuthProviderBase.
     // Swapping config with a values from config object.
-    $configObject = $container->get('config.factory')->get(AuthProviderBaseSettingsForm::$configName);
+    $configObject = $container->get('config.factory')
+      ->get(AuthProviderBaseSettingsForm::$configName);
     if ($configurationSerialized = $configObject->get($plugin_id)) {
       $configuration = unserialize($configurationSerialized, ['allowed_classes' => FALSE]);
     }
@@ -167,7 +169,13 @@ class OpenIDConnect extends AuthProviderBase {
    *   The response.
    */
   public function login() {
-    $request = $this->requestStack->getCurrentRequest();
+    $info_page_url = Url::fromRoute('os2forms_nemlogin_openid_connect.info_page', [
+      'id' => $this->getPluginId(),
+    ])
+      ->toString(TRUE)
+      ->getGeneratedUrl();
+
+    return (new LocalRedirectResponse($info_page_url))->send();
 
     $token = $this->getToken();
     if (NULL === $token) {
@@ -275,13 +283,13 @@ class OpenIDConnect extends AuthProviderBase {
    */
   public function defaultConfiguration() {
     return parent::defaultConfiguration() + [
-      'nemlogin_openid_connect_discovery_url' => '',
-      'nemlogin_openid_connect_client_id' => '',
-      'nemlogin_openid_connect_client_secret' => '',
-      'nemlogin_openid_connect_fetch_once' => '',
-      'nemlogin_openid_connect_post_logout_redirect_uri' => '',
-      'nemlogin_openid_connect_user_claims' => '',
-    ];
+        'nemlogin_openid_connect_discovery_url' => '',
+        'nemlogin_openid_connect_client_id' => '',
+        'nemlogin_openid_connect_client_secret' => '',
+        'nemlogin_openid_connect_fetch_once' => '',
+        'nemlogin_openid_connect_post_logout_redirect_uri' => '',
+        'nemlogin_openid_connect_user_claims' => '',
+      ];
   }
 
   /**

--- a/templates/os2forms-nemlogin-openid-connect-intermediary-info-page.html.twig
+++ b/templates/os2forms-nemlogin-openid-connect-intermediary-info-page.html.twig
@@ -1,0 +1,2 @@
+<h1>Velkommen!</h1>
+<a href="{{ redirect_url }}">Fortsæt med AD login</a>


### PR DESCRIPTION
- **Hook into login, and redirect to info-page instead of auth**
- **Get auth url and render info page via template**
- **Add routing for info page**
- **Add new template to theme hook**
- **Added template for info page**
