### PR TITLE
Added support for itk-dev/openid-connect 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.4.0] 2026-04-20
+
+* Added support for `itk-dev/openid-connect` 4.x.
+
 ## [2.3.1] 2025-12-12
 
 * Correctly identify form configured OIDC providers.
@@ -41,7 +45,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Allowed multiple providers.
 
-[Unreleased]: https://github.com/itk-dev/os2forms_nemlogin_openid_connect/compare/2.3.1...HEAD
+[Unreleased]: https://github.com/itk-dev/os2forms_nemlogin_openid_connect/compare/2.4.0...HEAD
+[2.4.0]: https://github.com/itk-dev/os2forms_nemlogin_openid_connect/compare/2.3.1...2.4.0
 [2.3.1]: https://github.com/itk-dev/os2forms_nemlogin_openid_connect/compare/2.3.0...2.3.1
 [2.3.0]: https://github.com/itk-dev/os2forms_nemlogin_openid_connect/compare/2.2.1...2.3.0
 [2.2.1]: https://github.com/itk-dev/os2forms_nemlogin_openid_connect/compare/2.2.0...2.2.1

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "drupal/webform": "^6.0",
         "itk-dev/drupal_psr6_cache": "^1.1",
-        "itk-dev/openid-connect": "^3.1",
+        "itk-dev/openid-connect": "^3.1 || ^4.0",
         "os2web/os2web_audit": "^1.0",
         "os2web/os2web_key": "^1.0",
         "os2web/os2web_nemlogin": "^1.2",


### PR DESCRIPTION
* Adds support for `itk-dev/openid-connect:^4.x`. See `itk-dev/openid-connect` [releases](https://github.com/itk-dev/openid-connect/releases) for available versions. 
  * Allows for upgrade to `firebase/php-jwt:^7.0`
  * Handles `aud` being an array of audiences